### PR TITLE
Updated bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "pizza",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": [
-    "dist/css/pizza.min.css",
+    "dist/css/pizza.css",
     "dist/js/pizza.js"
   ],
   "dependencies": {


### PR DESCRIPTION
I changed the CSS reference from 
```
dist/css/pizza.min.css
```
to 
```
dist/css/pizza.css
```
...since there isn't a minified CSS file included with the package. 

It's minor, but it becomes an issue when working with tools like [wiredep](https://github.com/taptapship/wiredep), which automatically injects your bower components into your source code by reading the references listed in a package's `bower.json`.

I also bumped the version to `0.2.3`