### PR TITLE
Add jQuery to Example index.html (fixes #34)

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
   </div>
 
   <br><br><br>
-
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
   <script src="dist/js/vendor/dependencies.js"></script>
   <script src="dist/js/pizza.js"></script>
   <script>


### PR DESCRIPTION
The example doesn't work right 'out of the box', which defeats the point of the example.

This adds a jQuery CDN link to the index.html to enable the example to work.